### PR TITLE
[chore] Update content-to-json nodeJS script to use template literals instead of string concatenation

### DIFF
--- a/tasks/content-to-json.js
+++ b/tasks/content-to-json.js
@@ -6,15 +6,15 @@ const articles = ['navigating-the-ddr-ui', 'setting-your-speed', 'why-play-ddr',
 const resources = ['glossary'];
 
 articles.forEach(article_base => {
-    const article_src = 'content/articles/' + article_base + '.md';
-    const article_dest = 'src/content/articles/' + article_base + '.json';
+    const article_src = `content/articles/${article_base}.md`;
+    const article_dest = `src/content/articles/${article_base}.json`;
     const contents = frontmatter(fs.readFileSync(article_src, 'utf8'));
     fs.writeFileSync(article_dest, JSON.stringify(contents));
 });
 
 resources.forEach(resource_base => {
-    const resource_src = 'content/resources/' + resource_base + '.yml';
-    const resource_dest = 'src/content/resources/' + resource_base + '.json';
+    const resource_src = `content/resources/${resource_base}.yml`;
+    const resource_dest = `src/content/resources/${resource_base}.json`;
     const contents = yaml.safeLoad(fs.readFileSync(resource_src, 'utf8'));
     fs.writeFileSync(resource_dest, JSON.stringify(contents));
 });


### PR DESCRIPTION
As of nodeJS 4.0.0, support for template literals/template strings should be in place. Template literals are usually a cleaner way to express filepaths that rely on a dynamically interpolated value, as opposed to string addition/concatenation.

More info:
https://nodejs.org/en/blog/release/v4.0.0/
https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Template_literals
